### PR TITLE
Minimum Java version set to 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Configure your project's `pom.xml` to run the plugin during the project's build 
 </build>
 ```
 
-This plugin requires Java 8.
+This plugin requires Java 11.
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
     </distributionManagement>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skipTests>true</skipTests>


### PR DESCRIPTION
, as the Google Closure Compiler requires at least Java 11