### PR TITLE
Documentation and pom.xml changes for version 1.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # Minify Maven Plugin
 
-## 1.7.9 (upcoming)
+## 1.7.9 (December 12th, 2024)
 
-* Library and Maven plugin updates, most importantly Google Clousure Compiler upgrade from v20230228 to v20240317
+* Library and Maven plugin updates
 * Minimum Java version set to 11, as Google Closure Compiler requires it
+* Automatic dependency updates using Dependabot
+* Modernized Maven Site (Fluido skin update, `site.xml` structure)
+* Improved documentation
+* Deployment is now done using Maven `maven-deploy-plugin` instead of `maven-release-plugin`
+* Fixed Maven build warnings
+* Added plugin and configuration for publishing Maven Site to Github Pages (replacing the ancient github-site-plugin)
+* Added documentation for project contributors to deploy the project at https://github.com/sevenprinciplesmobility/minify-maven-plugin/blob/main/DEPLOYMENT.md
 
 ## 1.7.8 (May 19th, 2023)
 
-* Fixed [issue #1 - Sourcemap files contain absolute paths](https://github.com/sevenprinciples/minify-maven-plugin/issues/1)
+* Fixed [issue #1 - Sourcemap files contain absolute paths](https://github.com/sevenprinciplesmobility/minify-maven-plugin/issues/1)
 
 ## 1.7.7 (March 27th, 2023)
 
@@ -161,7 +168,7 @@
 ## 1.3
 
 * Change exclude/include patterns from a comma separated `String` to `List<String>`. Also included a custom file comparator that only compares the file name instead of the full file path.
-* Update [YUI Compressor](http://yui.github.com/yuicompressor/) dependency to version 2.4.2.
+* Update [YUI Compressor](http://yui.github.io/yuicompressor/) dependency to version 2.4.2.
 
 ## 1.2.1
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -11,7 +11,7 @@ This document is intended for maintainers of this repository.
 ### settings.xml
 ```xml
 <server>
-  <id>ossrh</id>
+  <id>ossrh-central</id>
   <username>user</username>
   <password>password</password>
 </server>

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,80 @@
+# Deploying the project
+
+This document is intended for maintainers of this repository. 
+
+## Pre-requisites for Maven Central deployments
+
+- an account at https://oss.sonatype.org/ 
+- `settings.xml` for Maven configured with a server block with id `ossrh` (see example below)
+- a gpg key with signing capabilities (preferrably a subkey). If you want to select a specific (sub)key you can use a Maven profile
+
+### settings.xml
+```xml
+<server>
+  <id>ossrh</id>
+  <username>user</username>
+  <password>password</password>
+</server>
+<!-- (...) -->
+<profiles>
+    <profile>
+        <id>minify-signing</id>
+        <properties>
+            <gpg.keyname>ABCDEFGH!</gpg.keyname>
+        </properties>
+    </profile>
+</profiles>
+```
+### Checking if signing with gpg works
+
+You can execute `mvn -P minify-signing package gpg:sign` to check if the signing works. You should get an output like
+```text
+[INFO] --- gpg:3.2.7:sign (default-cli) @ minify-maven-plugin ---
+[INFO] Signer 'gpg' is signing 4 files with key 4FF41C5D!
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+and you should have 8 `.asc` files in the `target` directory:
+```text
+minify-maven-plugin-1.7.9-SNAPSHOT-javadoc.jar.asc
+minify-maven-plugin-1.7.9-SNAPSHOT-sources.jar.asc
+minify-maven-plugin-1.7.9-SNAPSHOT.jar.asc
+minify-maven-plugin-1.7.9-SNAPSHOT.pom.asc
+minify-maven-plugin-1.7.9-javadoc.jar.asc
+minify-maven-plugin-1.7.9-sources.jar.asc
+minify-maven-plugin-1.7.9.jar.asc
+minify-maven-plugin-1.7.9.pom.asc
+```
+You should be verify any file like this:
+```shell
+gpg --verify target/minify-maven-plugin-1.7.9-SNAPSHOT.jar.asc
+```
+and get an output like
+```text
+gpg: assuming signed data in 'target/minify-maven-plugin-1.7.9-SNAPSHOT.jar'
+gpg: Signature made Mi 12 Dez 2024 07:09:19 CET
+gpg:                using EDDSA key F1AA1D21D6C9FD73FFF9C5AD89ABA1774FF41C5D
+gpg: Good signature from "Danny Developer (7P Mobility GmbH | Seven Principles AG) <danny.developer@7p-group.com>" [ultimate]
+```
+
+## Deploying a snapshot to Maven Central (OSSRH)
+
+Currently the deployment is a manual process. Process:
+1. Ensure that the project version ends with `SNAPSHOT`, e.g. `1.7.9-SNAPSHOT`
+2. Run `mvn tidy:pom`
+3. Check that the project compiles and all tests are green
+4. Check that there are no uncommitted or unpushed changes
+5. Execute `mvn deploy -DreleaseTargetAndDeploymentType=ossrh-snapshot -P minify-signing`
+
+## Deploying a release to Maven Central (OSSRH)
+
+Currently the deployment is a manual process. Process:
+1. Ensure that the project version does not end with `SNAPSHOT`, i.e. it should be like `1.7.9`
+2. Ensure that all documentation (`CHANGELOG.md`, `README.MD`) have the correct version strings
+3. Run `mvn tidy:pom`
+4. Check that the project compiles and all tests are green
+5. Check that there are no uncommitted or unpushed changes
+6. Execute `mvn deploy -DreleaseTargetAndDeploymentType=ossrh-release -P minify-signing`
+7. Tag the release with `minify-maven-plugin-${project.version}`, e.g. `minify-maven-plugin-1.7.9`
+8. Push the tag

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Minify Maven Plugin combines and minimizes your CSS and JavaScript files for fas
 
 Under the hood, it uses the [YUI Compressor]([https://github.com/yui/yuicompressor](https://github.com/yui/yuicompressor)) and [Google Closure Compiler](https://developers.google.com/closure/compiler/) but has a layer of abstraction around these tools which allows for other tools to be added in the future.
 
-Forked from https://github.com/samaxes/minify-maven-plugin in 2023 as the original version is apparently unmaintained. For changes in the forked version and earlier please see https://github.com/sevenprinciples/minify-maven-plugin/blob/main/CHANGELOG.md
+Forked from https://github.com/samaxes/minify-maven-plugin in 2023 as the original version is apparently unmaintained. For changes in the forked version and earlier please see https://github.com/sevenprinciplesmobility/minify-maven-plugin/blob/main/CHANGELOG.md
 
 ## Benefits
 
@@ -24,7 +24,7 @@ Forked from https://github.com/samaxes/minify-maven-plugin in 2023 as the origin
 > Combined files are a way to reduce the number of HTTP requests by combining all scripts into a single script, and similarly combining all CSS into a single stylesheet. Combining files is more challenging when the scripts and stylesheets vary from page to page, but making this part of your release process improves response times.
 
 ### Compress JavaScript and CSS
-
+    
 > Minification/compression is the practice of removing unnecessary characters from code to reduce its size thereby improving load times. A JavaScript compressor, in addition to removing comments and white-spaces, obfuscates local variables using the smallest possible variable name. This improves response time performance because the size of the downloaded file is reduced.
 
 ## Usage
@@ -37,7 +37,7 @@ Configure your project's `pom.xml` to run the plugin during the project's build 
     <plugin>
       <groupId>com.7p-group</groupId>
       <artifactId>minify-maven-plugin</artifactId>
-      <version>1.7.8</version>
+      <version>1.7.9-SNAPSHOT</version>
       <executions>
         <execution>
           <id>default-minify</id>
@@ -66,6 +66,8 @@ Configure your project's `pom.xml` to run the plugin during the project's build 
 ```
 
 This plugin requires Java 11.
+
+For more documentation see the project's documentation website at https://github.io/sevenprinciplesmobility/minify-maven-plugin
 
 ## License
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Minify Maven Plugin Demo</name>
     <description>Demonstrate how to use minify-maven-plugin.</description>
-    <url>https://github.com/sevenprinciples/minify-maven-plugin</url>
+    <url>https://github.com/sevenprinciplesmobility/minify-maven-plugin</url>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,10 @@
         <profile>
             <id>nexus</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>releaseTargetAndDeploymentType</name>
+                </property>
             </activation>
             <distributionManagement>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.7p-group</groupId>
     <artifactId>minify-maven-plugin</artifactId>
-    <version>1.7.9-SNAPSHOT</version>
+    <version>1.7.9</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,16 @@
 
     <groupId>com.7p-group</groupId>
     <artifactId>minify-maven-plugin</artifactId>
-    <version>1.7.9-SNAPSHOT</version>
+    <version>1.7.9</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Combine and minimize JavaScript and CSS files for faster page loading.</description>
-    <url>https://github.com/sevenprinciples/minify-maven-plugin</url>
+    <url>https://github.com/sevenprinciplesmobility/minify-maven-plugin</url>
     <inceptionYear>2009</inceptionYear>
     <organization>
         <name>SEVEN PRINCIPLES</name>
-        <url>https://github.com/sevenprinciples</url>
+        <url>https://github.com/sevenprinciplesmobility</url>
     </organization>
     <licenses>
         <license>
@@ -27,8 +27,8 @@
         <developer>
             <name>Sasu Welling</name>
             <email>sasu.welling@7p-group.com</email>
-            <organization>7p-group.com</organization>
-            <organizationUrl>https://7p-group.com</organizationUrl>
+            <organization>SEVEN PRINCIPLES MOBILITY GMBH</organization>
+            <organizationUrl>https://7p-mobility.com/en/</organizationUrl>
         </developer>
     </developers>
 
@@ -37,26 +37,27 @@
     </prerequisites>
 
     <scm>
-        <connection>scm:git:https://github.com/sevenprinciples/minify-maven-plugin.git</connection>
-        <!--
-        <developerConnection>scm:git:ssh://git@github.com:sevenprinciples/minify-maven-plugin.git</developerConnection>
-        -->
+        <connection>scm:git:https://github.com/sevenprinciplesmobility/minify-maven-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:sevenprinciples/minify-maven-plugin.git</developerConnection>
-        <url>https://github.com/sevenprinciples/minify-maven-plugin</url>
+        <url>https://github.com/sevenprinciplesmobility/minify-maven-plugin</url>
         <tag>minify-maven-plugin-1.7.7</tag>
     </scm>
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/sevenprinciples/minify-maven-plugin/issues</url>
+        <url>https://github.com/sevenprinciplesmobility/minify-maven-plugin/issues</url>
     </issueManagement>
     <distributionManagement>
+        <site>
+            <id>github</id>
+            <url>scm:git:git@github.com:sevenprinciplesmobility/minify-maven-plugin.git</url>
+        </site>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>ossrh-central</id>
+            <url>${nexus.url}</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>ossrh-central</id>
+            <url>${nexus.url}</url>
         </repository>
     </distributionManagement>
 
@@ -66,11 +67,15 @@
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <skipTests>true</skipTests>
-        <github.global.server>github</github.global.server>
+
+        <!-- Versions -->
+        <!-- Versions: Maven -->
         <maven.api.version>3.0</maven.api.version>
+
+        <!-- Versions: plugins -->
         <maven.plugin.version>3.15.1</maven.plugin.version>
         <maven.javadoc.version>3.11.2</maven.javadoc.version>
+        <doxiaVersion>2.0.0</doxiaVersion>
     </properties>
 
     <dependencies>
@@ -111,6 +116,131 @@
             <artifactId>gson</artifactId>
             <version>2.11.0</version>
             <optional>true</optional>
+        </dependency>
+
+        <!-- Site -->
+        <dependency>
+            <groupId>org.apache.maven.skins</groupId>
+            <artifactId>maven-fluido-skin</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+
+        <!-- Doxia -->
+        <!-- The sl4j exclusions are necessary to prevent slf4j version 1.x from propagating to child POMs -->
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-sink-api</artifactId>
+            <version>${doxiaVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-core</artifactId>
+            <version>${doxiaVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-xhtml5</artifactId>
+            <version>${doxiaVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-apt</artifactId>
+            <version>${doxiaVersion}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-xdoc</artifactId>
+            <version>${doxiaVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-fml</artifactId>
+            <version>${doxiaVersion}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-module-markdown</artifactId>
+            <version>${doxiaVersion}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Doxia Sitetools -->
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-site-model</artifactId>
+            <version>${doxiaVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-site-renderer</artifactId>
+            <version>${doxiaVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-integration-tools</artifactId>
+            <version>${doxiaVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
@@ -184,69 +314,93 @@
                         <goals>
                             <goal>helpmojo</goal>
                         </goals>
+                        <configuration>
+                            <helpPackageName>com.sevenprinciplesmobility.maven.minify.plugin</helpPackageName>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
 
-            <!--
-                Perform a release deployment:
-                $ mvn release:clean release:prepare
-                $ mvn release:perform
-            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>release</releaseProfiles>
-                    <goals>deploy</goals>
-                </configuration>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
             </plugin>
-            <!--
-                Release the deployment to the central repository (automatically done by mvn release:perform):
-                $ cd target/checkout
-                $ mvn nexus-staging:release
-            -->
+
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <!--
-                Generate a new version of the Maven site:
-                $ cd target/checkout
-                $ mvn site
-            -->
-            <plugin>
-                <groupId>com.github.github</groupId>
-                <artifactId>site-maven-plugin</artifactId>
-                <version>0.12</version>
-                <configuration>
-                    <message>Creating site for ${project.version}</message>
-                    <dryRun>true</dryRun>
-                    <noJekyll>true</noJekyll>
-                </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
+                        <id>attach-sources</id>
                         <goals>
-                            <goal>site</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
-                        <phase>site</phase>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <doclint>all,-missing</doclint>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.6.0</version>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.21.0</version>
+                <configuration>
+                    <inputEncoding>UTF-8</inputEncoding>
+                    <outputEncoding>UTF-8</outputEncoding>
+                    <siteDirectory>${project.basedir}/src/site</siteDirectory>
+                    <chmod>true</chmod>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-scm-publish-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <scmBranch>gh-pages</scmBranch>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -260,18 +414,14 @@
                 <reportSets>
                     <reportSet>
                         <reports>
-                            <report>cim</report>
                             <report>dependencies</report>
-                            <report>dependency-convergence</report>
                             <report>dependency-info</report>
-                            <report>dependency-management</report>
-                            <report>issue-tracking</report>
-                            <report>license</report>
+                            <report>scm</report>
+                            <report>issue-management</report>
+                            <report>distribution-management</report>
+                            <report>index</report>
                             <report>plugin-management</report>
                             <report>plugins</report>
-                            <report>project-team</report>
-                            <report>scm</report>
-                            <report>summary</report>
                         </reports>
                     </reportSet>
                 </reportSets>
@@ -281,15 +431,21 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven.javadoc.version}</version>
                 <configuration>
-                    <linksource>true</linksource>
-                    <quiet>true</quiet>
-                    <links>
-                        <link>http://docs.oracle.com/javase/7/docs/api/</link>
-                        <link>http://docs.oracle.com/javaee/7/api/</link>
-                        <link>http://maven.apache.org/ref/${maven.api.version}/maven-core/apidocs/</link>
-                        <link>http://maven.apache.org/ref/${maven.api.version}/maven-plugin-api/apidocs/</link>
-                    </links>
+                    <show>public</show>
+                    <doctitle>${project.name}</doctitle>
+                    <encoding>UTF-8</encoding>
+                    <doclint>all,-missing</doclint>
+                    <additionalOptions>
+                    </additionalOptions>
                 </configuration>
+                <reportSets>
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -298,56 +454,87 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <version>${maven.plugin.version}</version>
+                <artifactId>maven-plugin-report-plugin</artifactId>
+                <version>3.15.1</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
         </plugins>
     </reporting>
 
     <profiles>
+        <!-- Deployment profiles. The profile is determined by
+            1. release target (ossrh/staging), i.e. Maven Central (OSSRH) or Staging Repo for testing
+            2. deployment type (snapshot/release)
+            As profile activatation in Maven 3.x is not possible with multiple properties,
+            the properties are combined using an environment variable "releaseTargetAndDeploymentType"
+        -->
+        <!-- To publish release to Maven Central (OSSRH) -->
+        <!-- mvn deploy -DreleaseTargetAndDeploymentType=ossrh-release -->
+
+        <!-- To deploy snapshot to Maven Central (OSSRH)) -->
+        <!-- mvn deploy -DreleaseTargetAndDeploymentType=ossrh-snapshot -->
+
+        <!-- To deploy release to local Sonatype Nexus server -->
+        <!-- Configure profile in ~/.m2/settings.xml and set nexus.url to your local Nexus server -->
+        <!-- mvn deploy -DreleaseTargetAndDeploymentType=staging-release -->
+
+        <!-- To deploy snapshot to Sonatype Nexus server -->
+        <!-- Configure profile in ~/.m2/settings.xml and set nexus.url to your local Nexus server -->
+        <!-- mvn deploy -DreleaseTargetAndDeploymentType=staging-snapshot -->
         <profile>
-            <id>release</id>
+            <id>ossrh-snapshot</id>
+            <properties>
+                <nexus.url>https://oss.sonatype.org/content/repositories/snapshots/</nexus.url>
+            </properties>
+            <activation>
+                <property>
+                    <name>releaseTargetAndDeploymentType</name>
+                    <value>ossrh-snapshot</value>
+                </property>
+            </activation>
+        </profile>
+        <profile>
+            <id>ossrh-release</id>
+            <properties>
+                <nexus.url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</nexus.url>
+            </properties>
+            <activation>
+                <property>
+                    <name>releaseTargetAndDeploymentType</name>
+                    <value>ossrh-release</value>
+                </property>
+            </activation>
+        </profile>
+        <profile>
+            <id>nexus</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <distributionManagement>
+                <repository>
+                    <id>nexus-repo</id>
+                    <url>${nexus.url}</url>
+                </repository>
+                <snapshotRepository>
+                    <id>nexus-repo</id>
+                    <url>${nexus.url}</url>
+                </snapshotRepository>
+            </distributionManagement>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven.javadoc.version}</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.7</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                            <repositoryId>nexus-repo</repositoryId>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.7p-group</groupId>
     <artifactId>minify-maven-plugin</artifactId>
-    <version>1.7.9</version>
+    <version>1.7.9-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -357,20 +357,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.7</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
                 <version>0.6.0</version>
@@ -535,6 +521,20 @@
                             <skip>false</skip>
                             <repositoryId>nexus-repo</repositoryId>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.7</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/java/com/samaxes/maven/minify/common/package-info.java
+++ b/src/main/java/com/samaxes/maven/minify/common/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Configuration and utility classes.
+ */
+package com.samaxes.maven.minify.common;

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/common/Aggregation.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/common/Aggregation.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.samaxes.maven.minify.common;
+package com.sevenprinciplesmobility.maven.minify.common;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,10 +27,22 @@ import java.util.List;
 public class Aggregation {
 
     /**
-     * Defines the aggregation type.
+     * Creates a new Aggregation object
+     */
+    public Aggregation() {
+        super();
+    }
+
+    /**
+     * Represents the types of aggregation that can be performed.
+     * This enum is used to specify the type of content being aggregated.
      */
     public enum AggregationType {
-        css, js
+        /** Cascading Style Sheets (CSS) aggregation. */
+        css,
+
+        /** JavaScript (JS) aggregation. */
+        js
     }
 
     private AggregationType type;

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/common/AggregationConfiguration.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/common/AggregationConfiguration.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.samaxes.maven.minify.common;
+package com.sevenprinciplesmobility.maven.minify.common;
 
 import java.util.List;
 
@@ -26,6 +26,13 @@ import java.util.List;
 public class AggregationConfiguration {
 
     private List<Aggregation> bundles;
+
+    /**
+     * Creates a new AggregationConfiguration object
+     */
+    public AggregationConfiguration() {
+        super();
+    }
 
     /**
      * Gets the bundles.

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/common/ClosureConfig.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/common/ClosureConfig.java
@@ -18,7 +18,7 @@
  */
 //Apache 2.0 license compliance notice: this file has been changed since commit ae4f668469d134fe1726a61e0a08b4998f201c90
 
-package com.samaxes.maven.minify.common;
+package com.sevenprinciplesmobility.maven.minify.common;
 
 import com.google.javascript.jscomp.*;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
@@ -27,8 +27,6 @@ import com.google.javascript.jscomp.SourceMap.Format;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.samaxes.maven.minify.common.Strings;
 
 /**
  * <a href="https://developers.google.com/closure/compiler/">Google Closure Compiler</a> configuration.

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/common/Strings.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/common/Strings.java
@@ -1,4 +1,4 @@
-package com.samaxes.maven.minify.common;
+package com.sevenprinciplesmobility.maven.minify.common;
 
 /**
  * String utils

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/common/package-info.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/common/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Configuration and utility classes.
+ */
+package com.sevenprinciplesmobility.maven.minify.common;

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/package-info.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Root package for all new code.
+ */
+package com.sevenprinciplesmobility.maven.minify;

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/MinifyMojo.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/MinifyMojo.java
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 //Apache 2.0 license compliance notice: this file has been changed since commit a8ca3f04aa6a57c43036b8cf2f0e686d1d0f7c2c
-package com.samaxes.maven.minify.plugin;
+package com.sevenprinciplesmobility.maven.minify.plugin;
 
 import com.google.gson.Gson;
 import com.google.javascript.jscomp.*;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
-import com.samaxes.maven.minify.common.Aggregation;
-import com.samaxes.maven.minify.common.AggregationConfiguration;
-import com.samaxes.maven.minify.common.ClosureConfig;
+import com.sevenprinciplesmobility.maven.minify.common.Aggregation;
+import com.sevenprinciplesmobility.maven.minify.common.AggregationConfiguration;
+import com.sevenprinciplesmobility.maven.minify.common.ClosureConfig;
 import com.samaxes.maven.minify.common.YuiConfig;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -41,7 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import com.samaxes.maven.minify.common.Strings;
+import com.sevenprinciplesmobility.maven.minify.common.Strings;
 
 /**
  * Goal for combining and minifying CSS and JavaScript files.
@@ -49,6 +49,13 @@ import com.samaxes.maven.minify.common.Strings;
 //Apache 2.0 license compliance notice: this file has been changed since commit a8ca3f04aa6a57c43036b8cf2f0e686d1d0f7c2c
 @Mojo(name = "minify", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, threadSafe = true)
 public class MinifyMojo extends AbstractMojo {
+
+    /**
+     * Creates a new MinifyMojo object
+     */
+    public MinifyMojo() {
+        super();
+    }
 
     /**
      * Engine used for minification.

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/ProcessCSSFilesTask.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/ProcessCSSFilesTask.java
@@ -16,10 +16,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.samaxes.maven.minify.plugin;
+package com.sevenprinciplesmobility.maven.minify.plugin;
 
 import com.samaxes.maven.minify.common.YuiConfig;
-import com.samaxes.maven.minify.plugin.MinifyMojo.Engine;
+import com.sevenprinciplesmobility.maven.minify.plugin.MinifyMojo.Engine;
 import com.yahoo.platform.yui.compressor.CssCompressor;
 import org.apache.maven.plugin.logging.Log;
 

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/ProcessFilesTask.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/ProcessFilesTask.java
@@ -16,11 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.samaxes.maven.minify.plugin;
+package com.sevenprinciplesmobility.maven.minify.plugin;
 
 import com.samaxes.maven.minify.common.SourceFilesEnumeration;
 import com.samaxes.maven.minify.common.YuiConfig;
-import com.samaxes.maven.minify.plugin.MinifyMojo.Engine;
+import com.sevenprinciplesmobility.maven.minify.plugin.MinifyMojo.Engine;
 import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/ProcessJSFilesTask.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/ProcessJSFilesTask.java
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 //Apache 2.0 license compliance notice: this file has been changed since commit 5b5559d16704505185f3cee3115d89d584299f47
-package com.samaxes.maven.minify.plugin;
+package com.sevenprinciplesmobility.maven.minify.plugin;
 
 import com.google.javascript.jscomp.*;
-import com.samaxes.maven.minify.common.ClosureConfig;
+import com.sevenprinciplesmobility.maven.minify.common.ClosureConfig;
 import com.samaxes.maven.minify.common.JavaScriptErrorReporter;
 import com.samaxes.maven.minify.common.YuiConfig;
-import com.samaxes.maven.minify.plugin.MinifyMojo.Engine;
+import com.sevenprinciplesmobility.maven.minify.plugin.MinifyMojo.Engine;
 import com.yahoo.platform.yui.compressor.JavaScriptCompressor;
 import org.apache.maven.plugin.logging.Log;
 

--- a/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/package-info.java
+++ b/src/main/java/com/sevenprinciplesmobility/maven/minify/plugin/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Classes for minifying files and interacting with Maven.
+ */
+package com.sevenprinciplesmobility.maven.minify.plugin;

--- a/src/site/apt/examples/basic.apt.vm
+++ b/src/site/apt/examples/basic.apt.vm
@@ -17,9 +17,9 @@ Basic Configuration
     <plugins>
       <!-- ... -->
       <plugin>
-        <groupId>com.samaxes.maven</groupId>
+        <groupId>com.7p-group</groupId>
         <artifactId>minify-maven-plugin</artifactId>
-        <version>1.7.6</version>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <id>default-minify</id>

--- a/src/site/apt/examples/bundle.apt.vm
+++ b/src/site/apt/examples/bundle.apt.vm
@@ -18,9 +18,9 @@ Bundle Configuration
     <plugins>
       <!-- ... -->
       <plugin>
-        <groupId>com.samaxes.maven</groupId>
+        <groupId>com.7p-group</groupId>
         <artifactId>minify-maven-plugin</artifactId>
-        <version>1.7.6</version>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <id>bundle-minify</id>

--- a/src/site/apt/examples/exclude.apt.vm
+++ b/src/site/apt/examples/exclude.apt.vm
@@ -29,9 +29,9 @@ Exclude source files from WAR package
       </plugin>
       <!-- ... -->
       <plugin>
-        <groupId>com.samaxes.maven</groupId>
+        <groupId>com.7p-group</groupId>
         <artifactId>minify-maven-plugin</artifactId>
-        <version>1.7.6</version>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <id>default-minify</id>

--- a/src/site/apt/examples/patterns.apt.vm
+++ b/src/site/apt/examples/patterns.apt.vm
@@ -17,9 +17,9 @@ Using include/exclude patterns
     <plugins>
       <!-- ... -->
       <plugin>
-        <groupId>com.samaxes.maven</groupId>
+        <groupId>com.7p-group</groupId>
         <artifactId>minify-maven-plugin</artifactId>
-        <version>1.7.6</version>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <id>default-minify</id>

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -10,7 +10,7 @@ Minify Maven Plugin
 
   This plugin combines and minimizes your CSS and JavaScript files for faster page loading. It produces a merged and a minified version of your CSS and JavaScript resources which can be re-used across your project.
 
-  Under the hood, it uses the {{{http://yui.github.com/yuicompressor/}YUI Compressor}} and {{{https://developers.google.com/closure/compiler/}Google Closure Compiler}} but has a layer of abstraction around these tools which allows for other tools to be added in the future.
+  Under the hood, it uses the {{{http://yui.github.io/yuicompressor/}YUI Compressor}} and {{{https://developers.google.com/closure/compiler/}Google Closure Compiler}} but has a layer of abstraction around these tools which allows for other tools to be added in the future.
 
 * Goals Overview
 
@@ -20,7 +20,7 @@ Minify Maven Plugin
 
   General instructions on how to use the Minify Maven Plugin can be found on the {{{./usage.html}usage page}}. Some more specific use cases are described in the examples given below.
 
-  If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our {{{./issue-tracking.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason, entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated. Of course, patches are welcome, too. Contributors can check out the project from our {{{./source-repository.html}source repository}} and will find supplementary information in the {{{http://maven.apache.org/guides/development/guide-helping.html}guide to helping with Maven}}.
+  If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our {{{./issue-management.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason, entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated. Of course, patches are welcome, too. Contributors can check out the project from our {{{./scm.html}source repository}} and will find supplementary information in the {{{http://maven.apache.org/guides/development/guide-helping.html}guide to helping with Maven}}.
 
 * Examples
 

--- a/src/site/apt/usage.apt
+++ b/src/site/apt/usage.apt
@@ -42,9 +42,9 @@ Usage
     <plugins>
       <!-- ... -->
       <plugin>
-        <groupId>com.samaxes.maven</groupId>
+        <groupId>com.7p-group</groupId>
         <artifactId>minify-maven-plugin</artifactId>
-        <version>1.7.6</version>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <id>default-minify</id>

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -17,7 +17,7 @@
         <faq id="alternative-compilers">
             <question>Which JavaScript compressor engines does Minify Maven Plugin support?</question>
             <answer>
-                <p>Minify Maven Plugin supports <a href="http://yui.github.com/yuicompressor/">YUI Compressor</a> and <a href="https://developers.google.com/closure/compiler/">Google Closure Compiler</a>.</p>
+                <p>Minify Maven Plugin supports <a href="http://yui.github.io/yuicompressor/">YUI Compressor</a> and <a href="https://developers.google.com/closure/compiler/">Google Closure Compiler</a>.</p>
                 <p>Use the values <code>YUI</code> or <code>CLOSURE</code> with the option <code>&lt;jsEngine&gt;</code> to select the engine to use.</p>
             </answer>
         </faq>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,11 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project>
+<site>
     <publishDate position="right" format="yyyy-MM-dd"/>
     <version position="right"/>
 
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>2.0.0</version>
+    </skin>
+
+    <custom>
+        <fluidoSkin>
+            <leftColumnClass>span3</leftColumnClass>
+            <bodyColumnClass>span9</bodyColumnClass>
+            <gitHub>
+                <projectId>sevenprinciplesmobility/minify-maven-plugin</projectId>
+                <ribbonOrientation>right</ribbonOrientation>
+                <ribbonColor>red</ribbonColor>
+            </gitHub>
+            <facebookLike />
+            <googlePlusOne />
+        </fluidoSkin>
+    </custom>
+
     <body>
         <breadcrumbs>
-            <item name="Minify Maven Plugin" href="https://github.com/samaxes/minify-maven-plugin" />
+            <item name="Minify Maven Plugin" href="https://github.com/sevenprinciplesmobilitymobility/minify-maven-plugin" />
         </breadcrumbs>
 
         <menu ref="modules" />
@@ -24,27 +44,4 @@
         <menu ref="reports" />
     </body>
 
-    <skin>
-        <groupId>org.apache.maven.skins</groupId>
-        <artifactId>maven-fluido-skin</artifactId>
-        <version>1.5</version>
-    </skin>
-
-    <custom>
-        <fluidoSkin>
-            <leftColumnClass>span3</leftColumnClass>
-            <bodyColumnClass>span9</bodyColumnClass>
-            <gitHub>
-                <projectId>samaxes/minify-maven-plugin</projectId>
-                <ribbonOrientation>right</ribbonOrientation>
-                <ribbonColor>red</ribbonColor>
-            </gitHub>
-            <twitter>
-                <user>samaxes</user>
-                <showUser>true</showUser>
-            </twitter>
-            <facebookLike />
-            <googlePlusOne />
-        </fluidoSkin>
-    </custom>
-</project>
+</site>


### PR DESCRIPTION
- Modernized Maven Site (Fluido skin update, `site.xml` structure)
- Improved documentation
- Deployment is now done using Maven `maven-deploy-plugin` instead of `maven-release-plugin`
- Fixed Maven build warnings
- Added plugin and configuration for publishing Maven Site to Github Pages (replacing the ancient github-site-plugin)
- Added documentation for project contributors to deploy the project at https://github.com/sevenprinciplesmobility/minify-maven-plugin/blob/main/DEPLOYMENT.md